### PR TITLE
Add example to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ sdl2 = "0.29"
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.1"
+
+[[example]]
+name = "simple"


### PR DESCRIPTION
Added an `[[example]]` section to Cargo.toml. This enables the example located in `examples/simple.rs` to be run using `cargo run --example simple`. Adds a layer of simplicity.